### PR TITLE
Update badge links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SpookySwap SDK
 
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
-[![Actions Status](https://github.com/pancakeswap/pancakeswap-sdk/workflows/CI/badge.svg)](https://github.com/pancakeswap/pancakeswap-sdk)
-[![npm version](https://img.shields.io/npm/v/@pancakeswap-lib/sdk/latest.svg)](https://www.npmjs.com/package/@pancakeswap-lib/sdk/v/latest)
+[![Actions Status](https://github.com/spookyswap/spookyswap-sdk/workflows/CI/badge.svg)](https://github.com/spookyswap/spookyswap-sdk)
+[![npm version](https://img.shields.io/npm/v/spookyswap-sdk/latest.svg)](https://www.npmjs.com/package/spookyswap-sdk/v/latest)
 
 ## Running tests
 


### PR DESCRIPTION
The badges in the readme pointed to the wrong CI pipelines and the wrong NPM repo, so I updated the badge links to point to the correct resources.