### PR TITLE
windows build fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start": "tsdx watch",
     "test": "tsdx test",
     "prepublishOnly": "tsdx build",
-    "prepare": "rm -rf ./dist && yarn build"
+    "prepare": "rimraf ./dist && yarn build"
   },
   "dependencies": {
     "@uniswap/v2-core": "1.0.0",
@@ -50,6 +50,7 @@
     "@types/big.js": "^4.0.5",
     "@types/jest": "^24.0.25",
     "babel-plugin-transform-jsbi-to-bigint": "^1.3.1",
+    "rimraf": "^3.0.2",
     "tsdx": "^0.12.3"
   },
   "engines": {


### PR DESCRIPTION
switches from rm -rf to rimraf to avoid non unix build environment issues